### PR TITLE
Add repository structure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,20 @@ Then, point your web browser at:
 file:///path/to/checkout/docs/_build/html/index.html
 ```
 replacing `/path/to/checkout` with the absolute path of your git checkout.
+
+## Repository Structure
+
+The top-level directories in this repository hold different pieces of the
+project:
+
+- **`admin`** – YAML files that describe how the service is deployed on Spin.
+- **`client`** – the `fastdb_client.py` module used to access the API.
+- **`db`** – PostgreSQL database migration scripts.
+- **`docker`** – Docker definitions used for Spin and local tests.
+- **`docs`** – Sphinx documentation sources.
+- **`examples`** – Jupyter notebooks showing how to use FASTDB.
+- **`notes`** – assorted notes for developers.
+- **`share`** – source copies of `.avsc` files describing the alert schema.
+- **`src`** – web server code, services, admin utilities and supporting
+  libraries.
+- **`tests`** – the pytest test suite.


### PR DESCRIPTION
## Summary
- document repo directories in README

## Testing
- `pytest -q` *(fails: FileNotFoundError: /secrets/pgpasswd)*

------
https://chatgpt.com/codex/tasks/task_e_68794619c70c8321a033b411ff081c21